### PR TITLE
Handle missing sqlite3 db file with error mentioning file path

### DIFF
--- a/Ska/DBI/DBI.py
+++ b/Ska/DBI/DBI.py
@@ -11,6 +11,7 @@ Features:
 """
 import os
 import sys
+import warnings
 
 supported_dbis = ('sqlite', 'sybase')
 
@@ -86,10 +87,10 @@ class DBI(object):
             import sqlite3 as dbapi2
 
             # If the server is a file (not the special ':memory:' device)
-            # and that file does not exist, throw an error with the filename.
+            # and that file does not exist, warn.
             if self.server != ':memory:' and not os.path.exists(self.server):
-                raise dbapi2.OperationalError(
-                    "Database file {} does not exist".format(self.server))
+                warnings.warn(
+                    f"Database file missing: {self.server} does not exist.  Creating.")
             self.conn = dbapi2.connect(self.server)
 
         elif dbi == 'sybase':

--- a/Ska/DBI/DBI.py
+++ b/Ska/DBI/DBI.py
@@ -84,6 +84,8 @@ class DBI(object):
 
         if dbi == 'sqlite':
             import sqlite3 as dbapi2
+            if not os.path.exists(self.server):
+                raise dbapi2.OperationalError("Database file {} does not exist".format(self.server))
             self.conn = dbapi2.connect(self.server)
 
         elif dbi == 'sybase':

--- a/Ska/DBI/DBI.py
+++ b/Ska/DBI/DBI.py
@@ -84,8 +84,12 @@ class DBI(object):
 
         if dbi == 'sqlite':
             import sqlite3 as dbapi2
-            if not os.path.exists(self.server):
-                raise dbapi2.OperationalError("Database file {} does not exist".format(self.server))
+
+            # If the server is a file (not the special ':memory:' device)
+            # and that file does not exist, throw an error with the filename.
+            if self.server != ':memory:' and not os.path.exists(self.server):
+                raise dbapi2.OperationalError(
+                    "Database file {} does not exist".format(self.server))
             self.conn = dbapi2.connect(self.server)
 
         elif dbi == 'sybase':

--- a/Ska/DBI/__init__.py
+++ b/Ska/DBI/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .DBI import *
 
-__version__ = '3.8.2'
+__version__ = '3.9.0'
 
 
 def test(*args, **kwargs):

--- a/Ska/DBI/tests/test_dbi.py
+++ b/Ska/DBI/tests/test_dbi.py
@@ -7,6 +7,7 @@ Usage:
 
 import os
 import pytest
+import tempfile
 import numpy as np
 from Ska.DBI import DBI
 
@@ -37,6 +38,12 @@ class DBI_BaseTests(object):
             pass
         cls.db.cursor.close()
         cls.db.conn.close()
+
+    # Run an empty test to get the warning for no file (if running on a file)
+    # Ignore that warning in these tests.
+    @pytest.mark.filterwarnings("ignore:Database file missing")
+    def test_00_warning(self):
+        pass
 
     def test_05_force_drop_table(self):
         try:
@@ -90,11 +97,23 @@ class DBI_BaseTests(object):
         self.db.execute('drop table ska_dbi_test_table')
 
 
-class TestSqliteWithNumpy(DBI_BaseTests):
+class TestSqliteWithNumpyFile(DBI_BaseTests):
+    fh, fn = tempfile.mkstemp(suffix='.db3')
+    db_config = dict(dbi='sqlite', server=fn, numpy=True)
+    os.unlink(fn)
+
+
+class TestSqliteWithoutNumpyFile(DBI_BaseTests):
+    fh, fn = tempfile.mkstemp(suffix='.db3')
+    db_config = dict(dbi='sqlite', server=fn, numpy=False)
+    os.unlink(fn)
+
+
+class TestSqliteWithNumpyMemory(DBI_BaseTests):
     db_config = dict(dbi='sqlite', server=':memory:', numpy=True)
 
 
-class TestSqliteWithoutNumpy(DBI_BaseTests):
+class TestSqliteWithoutNumpyMemory(DBI_BaseTests):
     db_config = dict(dbi='sqlite', server=':memory:', numpy=False)
 
 


### PR DESCRIPTION
This replaces`OperationalError: unable to open database file` with something like `OperationalError: Database file /proj/sot/ska/jeanproj/git/mica/bogusarchive/obspar/archfiles.db3 does not exist` for missing sqlite3 database files.  I think this would be more clear in general; this comes up, obviously if mica archive files are missing.

