### PR TITLE
Sqsh output looks to be latin-1 so fix decoding

### DIFF
--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -70,7 +70,7 @@ class Sqsh(object):
         Context manager exit run time context.
         """
 
-    def fetch(self, query):
+    def fetch(self, query, encoding="latin1"):
         """
         Execute a query and return all returned sql rows a list of lines.
 
@@ -82,6 +82,10 @@ class Sqsh(object):
         ----------
         query : str
             SQL query to execute (select statements are expected for our use cases)
+
+        encoding : str, optional
+            The encoding to use for decoding the output from sqsh. If not provided, the default
+            encoding is used (latin1).
 
         Returns
         -------
@@ -110,10 +114,10 @@ class Sqsh(object):
             cmd,
             env=cmd_env,
         )
-        outlines = stdout.decode("latin-1").splitlines()
+        outlines = stdout.decode(encoding).splitlines()
         return outlines
 
-    def fetchall(self, query):
+    def fetchall(self, query, encoding="latin1"):
         """
         Fetches all the rows returned by the query.
 
@@ -122,17 +126,21 @@ class Sqsh(object):
         query : str
             The SQL query to execute.
 
+        encoding : str, optional
+            The encoding to use for decoding the output from sqsh. If not provided, the default
+            encoding is used (latin1).
+
         Returns
         -------
         astropy.table.Table
             The table containing the fetched rows. If there are no rows that match the query,
             a zero-length table is returned.
         """
-        outlines = self.fetch(query)
+        outlines = self.fetch(query, encoding=encoding)
         tab = Table.read(outlines, format="ascii.csv")
         return tab
 
-    def fetchone(self, query):
+    def fetchone(self, query, encoding="latin1"):
         """
         Fetches the first row returned by the query.
 
@@ -141,11 +149,15 @@ class Sqsh(object):
         query : str
             The SQL query to execute.
 
+        encoding : str, optional
+            The encoding to use for decoding the output from sqsh. If not provided, the default
+            encoding is used (latin1).
+
         Returns
         -------
         astropy.table.Row or None
         """
-        outlines = self.fetch(query)
+        outlines = self.fetch(query, encoding=encoding)
         # Sqsh should always be returning a header line -- return None if that's it.
         if len(outlines) <= 1:
             return None

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -110,7 +110,7 @@ class Sqsh(object):
             cmd,
             env=cmd_env,
         )
-        outlines = stdout.decode().splitlines()
+        outlines = stdout.decode("latin-1").splitlines()
         return outlines
 
     def fetchall(self, query):

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -8,6 +8,15 @@ ON_HEAD_NETWORK = on_head_network()
 
 
 @pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
+def test_fetch_not_utf8():
+    s = Sqsh(server="sqlsao", user="aca_ops", database="axafocat")
+    query = "select obsid, remarks from target where obsid = 15191"
+    dat = s.fetchone(query)
+    assert (dat["remarks"] ==
+    "Assumed roll of 184 degr (OK for role ± 20 deg, if more need to update parameters.")
+
+
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetch_axafapstat_lines():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -12,8 +12,10 @@ def test_fetch_not_utf8():
     s = Sqsh(server="sqlsao", user="aca_ops", database="axafocat")
     query = "select obsid, remarks from target where obsid = 15191"
     dat = s.fetchone(query)
-    assert (dat["remarks"] ==
-    "Assumed roll of 184 degr (OK for role ± 20 deg, if more need to update parameters.")
+    assert (
+        dat["remarks"]
+        == "Assumed roll of 184 degr (OK for role ± 20 deg, if more need to update parameters."
+    )
 
 
 @pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")


### PR DESCRIPTION
## Description

Sqsh output looks to be latin-1 so fix the decoding.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes 
```
----> 1 get_value_from_sybase("select obsid, remarks from target")

Cell In[3], line 3, in get_value_from_sybase(cmd)
      1 def get_value_from_sybase(cmd):
      2     conn = sqsh.Sqsh(dbi='sybase', server=_SERV, database = _DB, user = _USR, authdir = _AUTHDIR)
----> 3     result = conn.fetchall(cmd)
      4     return result

File /data/mta4/waaron/ska3-2025.2rc1/lib/python3.12/site-packages/ska_dbi/sqsh.py:131, in Sqsh.fetchall(self, query)
    116 def fetchall(self, query):
    117     """
    118     Fetches all the rows returned by the query.
    119 
   (...)
    129         a zero-length table is returned.
    130     """
--> 131     outlines = self.fetch(query)
    132     tab = Table.read(outlines, format="ascii.csv")
    133     return tab

File /data/mta4/waaron/ska3-2025.2rc1/lib/python3.12/site-packages/ska_dbi/sqsh.py:113, in Sqsh.fetch(self, query)
     94 cmd = [
     95     SQSH_BIN,
     96     "-X",
   (...)
    106     query,
    107 ]
    109 stdout = subprocess.check_output(
    110     cmd,
    111     env=cmd_env,
    112 )
--> 113 outlines = stdout.decode().splitlines()
    114 return outlines

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb1 in position 276998: invalid start byte
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
9272c7a8599c6682400691b1c16edb80cc5824fd
ska3-jeanconn-fido> pytest
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 31 items                                                                                                                 

ska_dbi/tests/test_dbi.py .......................                                                                            [ 74%]
ska_dbi/tests/test_sqsh.py ........                                                                                          [100%]

======================================================== 31 passed in 3.47s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit test added as a functional test.
