### PR TITLE
Update sqsh/SYBASE libraries to 16.1

### DIFF
--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -1,5 +1,4 @@
-# Copied originally from pandas. This config requires ruff >= 0.2.
-target-version = "py311"
+target-version = "py312"
 
 # fix = true
 lint.unfixable = []
@@ -42,10 +41,13 @@ lint.ignore = [
   "B028", # No explicit `stacklevel` keyword argument found
   "PLR0913", # Too many arguments to function call
   "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
+  "PLC0415", # `import` should be at the top-level of a file
+  "PLW1641", # Class implements `__hash__` if `__eq__` is implemented
 ]
 
 extend-exclude = [
   "docs",
+  "build",
 ]
 
 [lint.pycodestyle]

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -5,9 +5,9 @@ from astropy.table import Table
 
 from ska_dbi.common import DEFAULT_CONFIG, NoPasswordError
 
-SYBASE = "/soft/SYBASE16.0"
+SYBASE = "/soft/SYBASE16.1"
 LD_LIBRARY_PATH = (
-    f"{SYBASE}/OCS-16_0/lib:{SYBASE}/OCS-16_0/lib3p64:{SYBASE}/OCS-16_0/lib3p"
+    f"{SYBASE}/OCS-16_1/lib:{SYBASE}/OCS-16_1/lib3p64:{SYBASE}/OCS-16_1/lib3p"
 )
 SQSH_BIN = "/usr/local/bin/sqsh.bin"
 


### PR DESCRIPTION
## Description

Update libraries in LD_LIBRARY_PATH to version 16.1 when calling sqsh.

This looks to be benign on kady (RH8) and owen-v (RH10) and shuts up warnings on chopper-v (Rocky Linux).

The chopper-v warnings looked like:
```
The context allocation routine failed.

The following problem caused the failure:

Invalid context version.
```
And those are visible with pytest -s
<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux on kady, owen-v, and chopper-v
```
jeanconn-owen-v> pytest -s
======================================== test session starts =========================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 31 items                                                                                   

ska_dbi/tests/test_dbi.py .......................
ska_dbi/tests/test_sqsh.py ........

========================================= 31 passed in 2.65s =========================================
jeanconn-owen-v> git rev-parse HEAD
a892f888ddd366b3e57c033c820b2603255e5369
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
